### PR TITLE
Update dependencies and fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is a Lowdefy 4 plugin that provides a new Connection, axios-oaut
 
 ## Usage
 
-This plugin is not released to any NPM repositories as a package. Rather, it is expected to be added to a Lowdefy monorepo under the plugins/ folder (e.g. using Git submodules). For more information on Lowdefy monorepos, please read the documentation for at [lowdefy-example-plugins](https://github.com/lowdefy/lowdefy-example-plugins). For more information on Git submodules, please refer to [Pro Git](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
+This plugin is not released to any NPM repositories as a package. Rather, it is expected to be added to a Lowdefy monorepo under the plugins/ folder (e.g. using Git submodules). For more information on Lowdefy monorepos, please read the documentation at [lowdefy-example-plugins](https://github.com/lowdefy/lowdefy-example-plugins). For more information on Git submodules, please refer to [Pro Git](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
 
 ### Example
 
@@ -57,7 +57,7 @@ pages:
     requests:
       - id: hello_get
         type: AxiosOAuth2ClientCredentials
-        connectionId: my_api
+        connectionId: my_oauth2_api
         properties:
           url: /hello
 ```
@@ -66,9 +66,9 @@ pages:
 
 This plugin is built on top of the existing Lowdefy Axios Connection, and extends its schema and its methods. Notably, the `auth` attribute of the connection (_not_ the request) is repurposed from being used to configure HTTP Basic authorization, and instead is used to configure the Client Credentials Grant token request.
 
-Access tokens are cached in-memory (per Lowdefy app node) for the lifetime of the token, based on the expires\_in response from the issuing server. No introspection of the token is performed, so any token type (opaque, JWT, etc) is supported. Locking is used to avoid making multiple concurrent requests for a token at startup or when at token is expired. A cluster running N nodes should therefore make no more than N client\_credentials grants per the token lifetime.
+Access tokens are cached in-memory (per Lowdefy app node) for the lifetime of the token, based on the expires\_in response from the issuing server. No introspection of the token is performed, so any token type (opaque, JWT, etc) is supported. Locking is used to avoid making multiple concurrent requests for a token at startup or when at token is expired. A cluster running N nodes should therefore make no more than N client\_credentials grants per the token lifetime. _For serverless deployments of Lowdefy: this token caching, as currently implemented, will much less effective, depending on how flat your concurrency is._
 
-For flexibility, parameters other than the token endpoint, client ID and client secret are specified as additional parameters, and are not subject to any schema verification, inspired by the configuration format used by `golang.org/x/oauth2/clientcredentials`.
+Parameters other than the token endpoint, client ID and client secret are specified as additional parameters, and are not subject to any schema verification, inspired by the configuration format used by `golang.org/x/oauth2/clientcredentials`.
 
 It is intentional that there are no npm/yarn/pnpm lockfiles in this repo: those will be at the base of your monorepo.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lowdefy-plugin-axios-oauth2-client-credentials",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -14,12 +14,12 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "axios": "1.2.2",
-    "@lowdefy/connection-axios-http": "4.0.0-rc.10",
+    "axios": "*",
+    "@lowdefy/connection-axios-http": "*",
     "node-cache": "^5.1.2"
   },
   "devDependencies": {
-    "eslint": "^8.47.0",
+    "eslint": "^8.51.0",
     "eslint-config-airbnb-base": "^15.0.0"
   }
 }


### PR DESCRIPTION
Instead of pinning to a specific Lowdefy version and the Axios dependency behind Lowdefy' axios connection plugin: just use `*` so that pnpm will reuse the version from the base Lowdefy installation.

Fix a few README typos, too.

Clarify that token caching assumes a persistant app instance, and will not work (as well) in serverless environments.