### PR TITLE
chore: update @lowdefy/connection-axios-http to v5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lowdefy-plugin-axios-oauth2-client-credentials",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "axios": "^1.15.2",
-    "@lowdefy/connection-axios-http": "^4.7.3",
+    "@lowdefy/connection-axios-http": "^5.1.0",
     "node-cache": "^5.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bump \`@lowdefy/connection-axios-http\` from \`^4.7.3\` to \`^5.1.0\` to support Lowdefy v5
- Bump plugin version to \`0.1.3\`

No source code changes required — the v5 package exports the same \`AxiosHttp\` connection under the same \`./connections\` path.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)