### PR TITLE
Upgrade lowdefy connection-axios-http pin from 5.3 to 5.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ src/
 
 | Package | Role |
 |---|---|
-| `@lowdefy/connection-axios-http` | Base connection; pinned to `^4.7.3` to match parent monorepo |
+| `@lowdefy/connection-axios-http` | Base connection; pinned to `^5.4.0` to match parent monorepo |
 | `axios` | HTTP client; pinned to `^1.15.2` |
 | `node-cache` | In-memory token cache |
 | ESLint + `eslint-config-airbnb-base` | Dev: linting |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The OAuth2 client\_credentials configuration MUST be on the connection definitio
 
 ```yaml
 ---
-lowdefy: 4.0.0-rc.10
+lowdefy: 5.4.0
 # [...]
 plugins:
   - name: 'lowdefy-plugin-axios-oauth2-client-credentials'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lowdefy-plugin-axios-oauth2-client-credentials",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "axios": "^1.15.2",
-    "@lowdefy/connection-axios-http": "^5.3.0",
+    "@lowdefy/connection-axios-http": "^5.4.0",
     "node-cache": "^5.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bump the `@lowdefy/connection-axios-http` dependency pin from `^5.3.0` to `^5.4.0` (latest 5.4.x release).
- Bump plugin version `0.1.3` -> `0.1.4`.
- Fix stale version references found while auditing:
  - `README.md`: example `lowdefy.yaml` snippet still referenced `lowdefy: 4.0.0-rc.10`, updated to `lowdefy: 5.4.0`.
  - `AGENTS.md`: dependency table said the base connection was "pinned to `^4.7.3`", updated to `^5.4.0`.

## Testing

- `npm install`
- `npm run lint` (passes)

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)